### PR TITLE
Added error code -2018: This Redemption Code is already in use

### DIFF
--- a/genshinstats/errors.py
+++ b/genshinstats/errors.py
@@ -90,6 +90,7 @@ def raise_for_error(response: dict):
         -2003: CodeRedeemException("Invalid redemption code"),
         -2007: CodeRedeemException("You have already used a redemption code of the same kind."),
         -2017: CodeRedeemException("Redemption code has been claimed already."),
+        -2018: CodeRedeemException("This Redemption Code is already in use"),
         -2001: CodeRedeemException("Redemption code has expired."),
         -2021: CodeRedeemException(
             "Cannot claim codes for account with adventure rank lower than 10."


### PR DESCRIPTION
I got this error code today, with the [Enchanting Journey of Snow and Stars](https://webstatic-sea.mihoyo.com/ys/event/e20211229-snow/index.html) event, after claiming personal code (already claimed).