### PR TITLE
Fixed issue with using multiple cookies

### DIFF
--- a/genshinstats/errors.py
+++ b/genshinstats/errors.py
@@ -69,6 +69,10 @@ class MissingAuthKey(AuthkeyError):
     """No gacha authkey was found."""
 
 
+class CookieUidMismatch(NotLoggedIn):
+    """Cookie doesn't match UID."""
+
+
 def raise_for_error(response: dict):
     """Raises a custom genshinstats error from a response."""
     # every error uses a different response code and message,
@@ -86,6 +90,7 @@ def raise_for_error(response: dict):
         ),
         -108: GenshinStatsException("Language is not valid."),
         10103: NotLoggedIn("Cookies are correct but do not have a hoyolab account bound to them."),
+        10104: CookieUidMismatch("Wrong cookie for the given UID"),
         # code redemption
         -2003: CodeRedeemException("Invalid redemption code"),
         -2007: CodeRedeemException("You have already used a redemption code of the same kind."),

--- a/genshinstats/genshinstats.py
+++ b/genshinstats/genshinstats.py
@@ -14,7 +14,7 @@ from urllib.parse import urljoin
 import requests
 from requests.sessions import RequestsCookieJar, Session
 
-from .errors import NotLoggedIn, TooManyRequests, raise_for_error
+from .errors import NotLoggedIn, TooManyRequests, raise_for_error, CookieUidMismatch
 from .pretty import (
     prettify_abyss,
     prettify_activities,
@@ -225,6 +225,9 @@ def fetch_endpoint(
         except TooManyRequests:
             # move the ratelimited cookie to the end to let the ratelimit wear off
             cookies.append(cookies.pop(0))
+        except CookieUidMismatch:
+            # move on to next cookie
+            pass
 
     # if we're here it means we used up all our cookies so we must handle that
     if len(cookies) == 1:


### PR DESCRIPTION
Hey there!

My main goal is to make a discord bot that is able to give any user the opportunity to register their cookie and token data to be able to get info about their account like current resin, characters, etc. as well as be able to redeem codes from discord chat through a command.

So far this wasn't working since every time more than one cookie was registered through the set_cookies function, only the earliest registered cookie would work. I found out this is because an exception is thrown anytime a cookie is checked against a UID that doesn't match the cookie, which stops the program from looping through the rest of the registered cookies.

I went ahead and made the according changes. If you have any questions or concerns please let me know!

I see you are working on Genshin.py now, but haven't seen any indication that it is meant to work for multiple users / cookies.
Do correct me if i'm wrong, but if I'm right, I would like to ask why that is the case. 

Thank you so much!